### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build-image-on-push.yaml
+++ b/.github/workflows/build-image-on-push.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Github Docker registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: robinj1995/github-review-request-reminder-slack-webhook/github-review-request-reminder-slack-webhook
         registry: ghcr.io


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore